### PR TITLE
Fix broken DenseNet model URL in fetch_models.sh

### DIFF
--- a/inference/models/fetch_models.sh
+++ b/inference/models/fetch_models.sh
@@ -11,4 +11,4 @@ wget -O model_repository/densenet_onnx/densenet_labels.txt \
      
 mkdir -p model_repository/densenet_onnx/1
 wget -O model_repository/densenet_onnx/1/model.onnx \
-     https://contentmamluswest001.blob.core.windows.net/content/14b2744cf8d6418c87ffddc3f3127242/9502630827244d60a1214f250e3bbca7/08aed7327d694b8dbaee2c97b8d0fcba/densenet121-1.2.onnx
+     https://github.com/onnx/models/raw/main/validated/vision/classification/densenet-121/model/densenet-7.onnx


### PR DESCRIPTION
## Description
This PR fixes a broken download link for the DenseNet ONNX model in the `fetch_models.sh` script.

## Problem
The current URL (Azure blob storage) is no longer accessible, causing the model download to fail when running the script.

## Reference
https://github.com/triton-inference-server/server/pull/7621